### PR TITLE
Add support for GitLab >= 11.5 env variables

### DIFF
--- a/src/ci-providers/gitlab-ci.ts
+++ b/src/ci-providers/gitlab-ci.ts
@@ -1,12 +1,18 @@
 import { CIProviderBase } from ".";
 
 export class GitlabCI extends CIProviderBase {
-  public static get ciNodeTotal(): void {
-    return undefined;
+  public static get ciNodeTotal(): string | void {
+    return process.env.CI_NODE_TOTAL;
   }
 
-  public static get ciNodeIndex(): void {
-    return undefined;
+  public static get ciNodeIndex(): string | void {
+    if (process.env.GITLAB_CI) {
+      const index = process.env.CI_NODE_INDEX; // GitLab >= 11.5
+
+      if (index) {
+        return (parseInt(index, 10) - 1).toString();
+      }
+    }
   }
 
   public static get ciNodeBuildId(): string | void {


### PR DESCRIPTION
Add support out of the box for GitLab CI environment variables for parallel CI nodes.

# Context
Since GitLab 11.5, you can define parallel: x (2 to 50) to a job and have it
run in multiple workers. You no longer need to define all of them
nor define any environmental variable manually.

You can read more from the documentation here:
https://docs.gitlab.com/ee/ci/yaml/#parallel

You can read about pre-defined ENV variables in GitLab CI here:
https://docs.gitlab.com/ee/ci/variables/README.html#predefined-variables-environment-variables