### PR TITLE
Export Knapsack Pro Logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './knapsack-pro-core';
+export * from './knapsack-pro-logger';
 export * from './models';
 export * from './types';


### PR DESCRIPTION
Now you can import logger from `@knapsack-pro/core`.