### PR TITLE
Reduce data transfer and speed up usage of Knapsack Pro API for Queue Mode

### DIFF
--- a/src/knapsack-pro-api.ts
+++ b/src/knapsack-pro-api.ts
@@ -32,16 +32,8 @@ export class KnapsackProAPI {
       node_total: KnapsackProEnvConfig.ciNodeTotal,
       node_index: KnapsackProEnvConfig.ciNodeIndex,
       node_build_id: KnapsackProEnvConfig.ciNodeBuildId,
+      ...(initializeQueue && { test_files: allTestFiles }),
     };
-
-    if (initializeQueue) {
-      const initData = {
-        ...data,
-        test_files: allTestFiles,
-      };
-
-      return this.api.post(url, initData);
-    }
 
     return this.api.post(url, data);
   }

--- a/src/knapsack-pro-api.ts
+++ b/src/knapsack-pro-api.ts
@@ -32,8 +32,16 @@ export class KnapsackProAPI {
       node_total: KnapsackProEnvConfig.ciNodeTotal,
       node_index: KnapsackProEnvConfig.ciNodeIndex,
       node_build_id: KnapsackProEnvConfig.ciNodeBuildId,
-      test_files: allTestFiles,
     };
+
+    if (initializeQueue) {
+      const initData = {
+        ...data,
+        test_files: allTestFiles,
+      };
+
+      return this.api.post(url, initData);
+    }
 
     return this.api.post(url, data);
   }


### PR DESCRIPTION
Don’t send test_files for already initialized Queue. Thanks to that we
reduce data transfer. This also makes requests much faster (even 10
times faster for test suite with 5000 test files).

# Related PR 
https://github.com/KnapsackPro/knapsack_pro-ruby/pull/81