### PR TITLE
Add support for job index and job count for parallelism in Semaphore 2.0

### DIFF
--- a/src/ci-providers/semaphore-ci-2.ts
+++ b/src/ci-providers/semaphore-ci-2.ts
@@ -1,12 +1,16 @@
 import { CIProviderBase } from '.';
 
 export class SemaphoreCI2 extends CIProviderBase {
-  public static get ciNodeTotal(): void {
-    return undefined;
+  public static get ciNodeTotal(): string | void {
+    return process.env.SEMAPHORE_JOB_COUNT;
   }
 
-  public static get ciNodeIndex(): void {
-    return undefined;
+  public static get ciNodeIndex(): string | void {
+    const jobIndex = process.env.SEMAPHORE_JOB_INDEX;
+
+    if (jobIndex) {
+      return (parseInt(jobIndex, 10) - 1).toString();
+    }
   }
 
   public static get ciNodeBuildId(): string | void {


### PR DESCRIPTION
* `SEMAPHORE_JOB_COUNT` - total number of jobs generated via parallelism property
* `SEMAPHORE_JOB_INDEX` - value in the range from 1 to `SEMAPHORE_JOB_COUNT` which represents the index of a particular job in the list of generated jobs.

https://docs.semaphoreci.com/article/50-pipeline-yaml#parallelism

Related PR: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/89