### PR TITLE
Fix not working Fallback Mode when using axios 0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2064,25 +2064,18 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
-      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
-        }
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "axios-retry": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.1.tgz",
-      "integrity": "sha512-BeNOxa/CBQQLa9gVuMta1oWIhbL6UETKBfAmFjOXwiBxgcmrDBVVwz/gKZTpzKJlVjmi5DeYC+lP5Ng7ssc1pg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.2.tgz",
+      "integrity": "sha512-+X0mtJ3S0mmia1kTVi1eA3DAC+oWnT2A29g3CpkzcBPMT6vJm+hn/WiV9wPt/KXLHVmg5zev9mWqkPx7bHMovg==",
       "requires": {
         "is-retry-allowed": "^1.1.0"
       }
@@ -4586,11 +4579,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
+      "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
       "requires": {
-        "debug": "=3.1.0"
+        "debug": "^3.0.0"
       }
     },
     "for-in": {
@@ -6020,8 +6013,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "url": "https://github.com/KnapsackPro/knapsack-pro-core-js/issues"
   },
   "dependencies": {
-    "axios": "^0.19.0",
-    "axios-retry": "^3.1.1",
+    "axios": "0.18.0",
+    "axios-retry": "^3.1.2",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/src/knapsack-pro-api.ts
+++ b/src/knapsack-pro-api.ts
@@ -171,7 +171,7 @@ export class KnapsackProAPI {
     const finalDelay = delay + randomSum;
 
     this.knapsackProLogger.info(
-      `Wait ${finalDelay} ms and retry request to Knapsack Pro API.`,
+      `(${retryCount}) Wait ${finalDelay} ms and retry request to Knapsack Pro API.`,
     );
 
     return finalDelay;

--- a/src/knapsack-pro-api.ts
+++ b/src/knapsack-pro-api.ts
@@ -164,9 +164,9 @@ export class KnapsackProAPI {
     return axiosRetry.isRetryableError(error);
   }
 
-  private retryDelay(retryNumber: number): number {
+  private retryDelay(retryCount: number): number {
     const requestRetryTimebox = 2000; // miliseconds
-    const delay = retryNumber * requestRetryTimebox;
+    const delay = retryCount * requestRetryTimebox;
     const randomSum = delay * 0.2 * Math.random(); // 0-20% of the delay
     const finalDelay = delay + randomSum;
 


### PR DESCRIPTION
# Problem

Since version `0.19.0` axios filter out custom properties in config , see https://github.com/axios/axios/issues/164#issuecomment-524756674

It means that `axios-retry` can't store retry number and will try to retry request to Knapsack Pro API infinitely.

Because of that Knapsack Pro Fallback Mode never started.

Related:
https://github.com/softonic/axios-retry/issues/89#issuecomment-526194639

# Fix

Workaround for this issue - downgrade to axios `0.18.0`

# Other changes

* Show `retryCount` number for each retried request.
* Update axios-retry to `3.1.2`