### PR TITLE
[breaking change] Add support for CI build ID for Github Actions - read PR description how to migrate for Github Actions

### DIFF
--- a/src/ci-providers/github-actions.ts
+++ b/src/ci-providers/github-actions.ts
@@ -1,6 +1,6 @@
 import { CIProviderBase } from '.';
 
-// https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
+// https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
 export class GithubActions extends CIProviderBase {
   public static get ciNodeTotal(): void {
     return undefined;
@@ -10,8 +10,10 @@ export class GithubActions extends CIProviderBase {
     return undefined;
   }
 
-  public static get ciNodeBuildId(): void {
-    return undefined;
+  public static get ciNodeBuildId(): string | void {
+    // A unique number for each run within a repository.
+    // This number does not change if you re-run the workflow run.
+    return process.env.GITHUB_RUN_ID;
   }
 
   public static get commitHash(): string | void {

--- a/src/ci-providers/github-actions.ts
+++ b/src/ci-providers/github-actions.ts
@@ -1,5 +1,6 @@
 import { CIProviderBase } from '.';
 
+// tslint:disable-next-line: max-line-length
 // https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
 export class GithubActions extends CIProviderBase {
   public static get ciNodeTotal(): void {


### PR DESCRIPTION
# what

This PR adds support for CI build ID for Github Actions. 

# why

* Thanks to that you can run concurrent CI builds for the same commit & branch in Knapsack Pro Queue Mode.
* Parallel jobs that started work after Queue was already consumed won't initialize a new Queue (thanks to that you won't accidentally run tests twice).

# Context

List of [env variables in Github Actions](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables).

`GITHUB_RUN_ID` - A unique number for each run within a repository. __This number does not change if you re-run the workflow run.__

# problem with GITHUB_RUN_ID - breaking change
When you retry parallel jobs in Github Actions then `GITHUB_RUN_ID` stays the same. Because of this in Knapsack Pro Queue Mode the Knapsack Pro API will assume the queue was already consumed for the CI build ID (`GITHUB_RUN_ID`) and no tests will run.

__WARNING__: This could accidentally make CI build green because no tests will run on retried CI build on Github Actions. 

__This is breaking change so we need to update the major release version after merge of this PR.__

# Migration path for Github Actions users - required

If you use Github Actions and Knapsack Pro Queue Mode then you must set in Github Actions environment variable: `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` ([more info how `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` works can be found in the installation guide for particular JS test runner supported by Knapsack Pro](https://docs.knapsackpro.com/integration/)). Thanks to that when you retry CI build then tests will run based on previously recorded tests. This solves problem mentioned in the previous section.



# Related PR
https://github.com/KnapsackPro/knapsack_pro-ruby/pull/116