### PR TITLE
When Knapsack Pro API returns expected errors then the CI node should fail and show an error from API response. Fix the problem with retrying failed request 3 times

### DIFF
--- a/src/knapsack-pro-api.ts
+++ b/src/knapsack-pro-api.ts
@@ -52,7 +52,7 @@ export class KnapsackProAPI {
     return this.api.post(url, data);
   }
 
-  public isExpectedErrorResponse(error: AxiosError) {
+  public isExpectedErrorStatus(error: AxiosError) {
     const { response } = error;
     if (!response) {
       return false;
@@ -166,7 +166,7 @@ export class KnapsackProAPI {
     return (
       axiosRetry.isNetworkError(error) ||
       this.isRetriableRequestError(error) ||
-      !this.isExpectedErrorResponse(error)
+      !this.isExpectedErrorStatus(error)
     );
   }
 

--- a/src/knapsack-pro-api.ts
+++ b/src/knapsack-pro-api.ts
@@ -52,6 +52,21 @@ export class KnapsackProAPI {
     return this.api.post(url, data);
   }
 
+  public isExpectedErrorResponse(error: AxiosError) {
+    const { response } = error;
+    if (!response) {
+      return false;
+    }
+
+    const { status } = response;
+
+    return (
+      status === 400 || // params error
+      status === 422 || // validation error
+      status === 403 // trial ended
+    );
+  }
+
   private setUpApiClient(
     clientName: string,
     clientVersion: string
@@ -149,7 +164,9 @@ export class KnapsackProAPI {
   // https://github.com/softonic/axios-retry/blob/master/es/index.js
   private retryCondition(error: AxiosError): boolean {
     return (
-      axiosRetry.isNetworkError(error) || this.isRetriableRequestError(error)
+      axiosRetry.isNetworkError(error) ||
+      this.isRetriableRequestError(error) ||
+      !this.isExpectedErrorResponse(error)
     );
   }
 

--- a/src/knapsack-pro-core.ts
+++ b/src/knapsack-pro-core.ts
@@ -58,16 +58,11 @@ export class KnapsackProCore {
         );
       })
       .catch((error) => {
-        const { response } = error;
-
-        if (response) {
-          const { status } = response;
-
-          if (status === 422 || status === 403) {
-            // CI build should fail
-            process.exitCode = 1;
-            throw new Error('Knapsack Pro API returned error. See above logs.');
-          }
+        if (this.knapsackProAPI.isExpectedErrorResponse(error)) {
+          // when API returned expected error then CI node should fail
+          // this should prevent from running tests in Fallback Mode
+          process.exitCode = 1;
+          throw new Error('Knapsack Pro API returned error. See above logs.');
         }
 
         onFailure(error);

--- a/src/knapsack-pro-core.ts
+++ b/src/knapsack-pro-core.ts
@@ -62,7 +62,9 @@ export class KnapsackProCore {
           // when API returned expected error then CI node should fail
           // this should prevent from running tests in Fallback Mode
           process.exitCode = 1;
-          throw new Error('Knapsack Pro API returned error. See above logs.');
+          throw new Error(
+            'Knapsack Pro API returned an error. See the above logs.'
+          );
         }
 
         onFailure(error);

--- a/src/knapsack-pro-core.ts
+++ b/src/knapsack-pro-core.ts
@@ -58,7 +58,7 @@ export class KnapsackProCore {
         );
       })
       .catch((error) => {
-        if (this.knapsackProAPI.isExpectedErrorResponse(error)) {
+        if (this.knapsackProAPI.isExpectedErrorStatus(error)) {
           // when API returned expected error then CI node should fail
           // this should prevent from running tests in Fallback Mode
           process.exitCode = 1;

--- a/src/knapsack-pro-core.ts
+++ b/src/knapsack-pro-core.ts
@@ -58,6 +58,18 @@ export class KnapsackProCore {
         );
       })
       .catch((error) => {
+        const { response } = error;
+
+        if (response) {
+          const { status } = response;
+
+          if (status === 422 || status === 403) {
+            // CI build should fail
+            process.exitCode = 1;
+            throw new Error('Knapsack Pro API returned error. See above logs.');
+          }
+        }
+
         onFailure(error);
 
         this.knapsackProLogger.warn(


### PR DESCRIPTION
# When Knapsack Pro API returns expected errors then the CI node should fail and show an error from API response.

API can return expected error like:

* 400 - bad request due to parsing params error (this would mean the structure of the request params is invalid)
* 403 - access denied due to trial ended (payment is required)
* 422 - unprocessable entity due to validation errors (for instance you did not provide commit hash in JSON payload for given API endpoint)

# This PR also fixes the problem with retrying failed request 3 times

*  When API returned non-expected errors from 4xx range (other than above 400, 403, 422) and the error response has a body then previously Fallback Mode was started immediately. Now there will be 3 request attempts. For instance, if API returns [499 error](https://devcenter.heroku.com/articles/error-codes#h27-client-request-interrupted) with a body then there will be 3 request attempts from now on.

* When API returns a response for a long time and there is timeout then now 3 requests attempt will be made before starting Fallback Mode.