### PR TITLE
Add support for `KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE` to specify the set of test files to run

### DIFF
--- a/__tests__/fixtures/test_file_list_source_file.txt
+++ b/__tests__/fixtures/test_file_list_source_file.txt
@@ -1,0 +1,4 @@
+__tests__/a.test.js
+__tests__/directory/b.test.js
+
+__tests__/c.test.js

--- a/__tests__/test-files-finder.spec.ts
+++ b/__tests__/test-files-finder.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef */
+import { TestFilesFinder } from '../src/test-files-finder';
+import { TestFile } from '../src/models';
+
+describe('TestFilesFinder', () => {
+  describe('.testFilesFromSourceFile', () => {
+    describe('when a file with the list of test files is not defined', () => {
+      it('returns null', () => {
+        expect(TestFilesFinder.testFilesFromSourceFile()).toEqual(null);
+      });
+    });
+
+    describe('when a file with the list of test files is defined', () => {
+      describe('when a file with the list of test files has an invalid path', () => {
+        it('throws an exception', () => {
+          process.env.KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE =
+            '__tests__/fixtures/fake_test_file_list_source_file.txt';
+
+          expect(() => {
+            TestFilesFinder.testFilesFromSourceFile();
+          }).toThrow(/^ENOENT: no such file or directory/);
+        });
+      });
+
+      describe('when a file with the list of test files has a valid path', () => {
+        it('returns test files and skips blank lines', () => {
+          process.env.KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE =
+            '__tests__/fixtures/test_file_list_source_file.txt';
+
+          const expectedTestFiles: TestFile[] = [
+            { path: '__tests__/a.test.js' },
+            { path: '__tests__/directory/b.test.js' },
+            { path: '__tests__/c.test.js' },
+          ];
+          expect(TestFilesFinder.testFilesFromSourceFile()).toMatchObject(
+            expectedTestFiles,
+          );
+        });
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint:format": "eslint . --ext .ts --fix",
     "prettier:check": "prettier --check .",
     "prettier:format": "prettier --config .prettierrc.json 'src/**/*.ts' --write",
-    "test": "jest",
+    "test": "jest --verbose",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "doctoc": "doctoc --title \"## Table of Contents\" README.md"

--- a/src/config/knapsack-pro-env.config.ts
+++ b/src/config/knapsack-pro-env.config.ts
@@ -179,4 +179,8 @@ export class KnapsackProEnvConfig {
   public static get logLevel(): string {
     return logLevel();
   }
+
+  public static get testFileListSourceFile(): string | void {
+    return process.env.KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE;
+  }
 }

--- a/src/knapsack-pro-core.ts
+++ b/src/knapsack-pro-core.ts
@@ -2,6 +2,7 @@ import { KnapsackProAPI } from './knapsack-pro-api';
 import { QueueApiResponseCodes } from './api-response-codes';
 import { KnapsackProLogger } from './knapsack-pro-logger';
 import { FallbackTestDistributor } from './fallback-test-distributor';
+import { TestFilesFinder } from './test-files-finder';
 import { TestFile } from './models';
 import { onQueueFailureType, onQueueSuccessType } from './types';
 
@@ -24,7 +25,8 @@ export class KnapsackProCore {
     allTestFiles: TestFile[],
   ) {
     this.recordedTestFiles = [];
-    this.allTestFiles = allTestFiles;
+    this.allTestFiles =
+      TestFilesFinder.testFilesFromSourceFile() ?? allTestFiles;
 
     this.knapsackProAPI = new KnapsackProAPI(clientName, clientVersion);
     this.knapsackProLogger = new KnapsackProLogger();

--- a/src/test-files-finder.ts
+++ b/src/test-files-finder.ts
@@ -1,4 +1,5 @@
 import { KnapsackProEnvConfig } from './config';
+import { KnapsackProLogger } from './knapsack-pro-logger';
 import { TestFile } from './models';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -9,6 +10,11 @@ export class TestFilesFinder {
     if (!KnapsackProEnvConfig.testFileListSourceFile) {
       return null;
     }
+
+    const knapsackProLogger = new KnapsackProLogger();
+    knapsackProLogger.debug(
+      `The KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE environment variable is defined. You will execute test files based on a list of test files from a file: ${KnapsackProEnvConfig.testFileListSourceFile}.`,
+    );
 
     const allFileContents = fs.readFileSync(
       KnapsackProEnvConfig.testFileListSourceFile,

--- a/src/test-files-finder.ts
+++ b/src/test-files-finder.ts
@@ -1,0 +1,34 @@
+import { KnapsackProEnvConfig } from './config';
+import { TestFile } from './models';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs');
+
+export class TestFilesFinder {
+  public static testFilesFromSourceFile(): TestFile[] {
+    if (!KnapsackProEnvConfig.testFileListSourceFile) {
+      return null;
+    }
+
+    const allFileContents = fs.readFileSync(
+      KnapsackProEnvConfig.testFileListSourceFile,
+      'utf-8',
+    );
+
+    const testFiles: TestFile[] = [];
+
+    allFileContents.split(/\r?\n/).forEach((line: string) => {
+      const testFilePath: string = line.trim();
+
+      if (testFilePath.length === 0) {
+        return;
+      }
+
+      testFiles.push({
+        path: testFilePath,
+      });
+    });
+
+    return testFiles;
+  }
+}

--- a/src/test-files-finder.ts
+++ b/src/test-files-finder.ts
@@ -13,7 +13,7 @@ export class TestFilesFinder {
 
     const knapsackProLogger = new KnapsackProLogger();
     knapsackProLogger.debug(
-      `The KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE environment variable is defined. You will execute test files based on a list of test files from a file: ${KnapsackProEnvConfig.testFileListSourceFile}.`,
+      `The KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE environment variable is defined. Knapsack will execute test files based on a list of test files from a file: ${KnapsackProEnvConfig.testFileListSourceFile}.`,
     );
 
     const allFileContents = fs.readFileSync(


### PR DESCRIPTION
When a `KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE` environment variable is defined, then read a list of test files from the file. Knapsack Pro is going to run these test files. This can be useful if you want to control/ generate your list of test files to be executed for a given CI build.

Example:

```
export KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE=.knapsack_pro/test_file_list_source_file.txt 
```

The file should contain the test file paths (each in a new line). Example:

```
__tests__/a.test.js
__tests__/b.test.js
__tests__/c.test.js
```

Note that blank lines are ignored. This means you can leave a new line at the end of the file.


When `KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE` is set, both `KNAPSACK_PRO_TEST_FILE_PATTERN` and `KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN` are ignored.

# related PR

* Test this PR on local machine with Jest example test suite https://github.com/KnapsackPro/jest-example-test-suite/pull/26
* Test this PR on local machine with Cypress kitchensink project https://github.com/KnapsackPro/cypress-example-kitchensink/pull/12

# related issue

https://github.com/KnapsackPro/knapsack-pro-jest/issues/58
