### PR TITLE
[breaking change] fix(feature): When the test file list source file is defined, then don't scan the disk for test files in the default location

### DIFF
--- a/src/knapsack-pro-core.ts
+++ b/src/knapsack-pro-core.ts
@@ -4,7 +4,11 @@ import { KnapsackProLogger } from './knapsack-pro-logger';
 import { FallbackTestDistributor } from './fallback-test-distributor';
 import { TestFilesFinder } from './test-files-finder';
 import { TestFile } from './models';
-import { onQueueFailureType, onQueueSuccessType } from './types';
+import {
+  onQueueFailureType,
+  onQueueSuccessType,
+  testFilesToExecuteType,
+} from './types';
 
 export class KnapsackProCore {
   private knapsackProAPI: KnapsackProAPI;
@@ -22,11 +26,11 @@ export class KnapsackProCore {
   constructor(
     clientName: string,
     clientVersion: string,
-    allTestFiles: TestFile[],
+    testFilesToExecute: testFilesToExecuteType,
   ) {
     this.recordedTestFiles = [];
     this.allTestFiles =
-      TestFilesFinder.testFilesFromSourceFile() ?? allTestFiles;
+      TestFilesFinder.testFilesFromSourceFile() ?? testFilesToExecute();
 
     this.knapsackProAPI = new KnapsackProAPI(clientName, clientVersion);
     this.knapsackProLogger = new KnapsackProLogger();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './on-queue-failure.type';
 export * from './on-queue-success.type';
+export * from './test-files-to-execute.type';

--- a/src/types/test-files-to-execute.type.ts
+++ b/src/types/test-files-to-execute.type.ts
@@ -1,0 +1,3 @@
+import { TestFile } from '../models';
+
+export type testFilesToExecuteType = () => TestFile[];


### PR DESCRIPTION
# problem

When `@knapsack-pro/core` is used by a client like `@knapsack-pro/jest` AND `KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE` is defined AND `KNAPSACK_PRO_TEST_FILE_PATTERN` matches no test files on the disk then `@knapsack-pro/jest` raises an error:

```
➜  jest-example-test-suite git:(fix-list-source) ✗ bin/knapsack_pro_jest_test_file_list_source_file

2023-01-31T14:22:05.946Z [@knapsack-pro/core] debug: Jest CLI options:
{ _: [] }

2023-01-31T14:22:06.264Z [@knapsack-pro/core] error: Test files cannot be found.
Please set KNAPSACK_PRO_TEST_FILE_PATTERN matching your test directory structure.
Learn more: https://knapsackpro.com/faq/question/how-to-run-tests-only-from-specific-directory-in-jest

/Users/artur/Documents/github/knapsack-pro/knapsack-for-js/knapsack-pro-jest/lib/test-files-finder.js:30
            throw errorMessage;
            ^
Test files cannot be found.
Please set KNAPSACK_PRO_TEST_FILE_PATTERN matching your test directory structure.
Learn more: https://knapsackpro.com/faq/question/how-to-run-tests-only-from-specific-directory-in-jest
(Use `node --trace-uncaught ...` to show where the exception was thrown)

Node.js v18.13.0
```

# solution

Don't call `testFilesToExecute()` if the test file list source file exists. This way we won't use `KNAPSACK_PRO_TEST_FILE_PATTERN` and scan files on the disk (which was happening on `@knapsack-pro/jest` level before). 

This means when `KNAPSACK_PRO_TEST_FILE_PATTERN` is invalid pattern then we won't see an error message raised by `@knapsack-pro/jest` when `KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE` is present.

Please remember that when `KNAPSACK_PRO_TEST_FILE_LIST_SOURCE_FILE` is set, both `KNAPSACK_PRO_TEST_FILE_PATTERN` and `KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN` are ignored. `KNAPSACK_PRO_TEST_FILE_PATTERN` and `KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN` are defined on the `@knapsack-pro/core` client level (for instance on `@knapsack-pro/jest` level).

# info

We make a breaking change in `KnapsackProCore` constructor. After merging this PR the new `@knapsack-pro/core` major version should be released.



