### PR TITLE
[breaking change] feat: KNAPSACK_PRO_CI_NODE_BUILD_ID required

### DIFF
--- a/__tests__/knapsack-pro-env.config.spec.ts
+++ b/__tests__/knapsack-pro-env.config.spec.ts
@@ -21,7 +21,7 @@ describe('KnapsackProEnvConfig', () => {
     });
 
     describe('when the build id is defined on a supported CI environment', () => {
-      it('returns it', () => {
+      it('returns the CI build ID for the supported CI provider', () => {
         const ciBuildId = 'some-build-id';
         process.env.GITHUB_RUN_ID = ciBuildId;
 

--- a/__tests__/knapsack-pro-env.config.spec.ts
+++ b/__tests__/knapsack-pro-env.config.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-undef */
+import { KnapsackProEnvConfig } from '../src/config/knapsack-pro-env.config';
+
+describe('KnapsackProEnvConfig', () => {
+  // Since we use CircleCI for testing, we prevent it from interfering with the tests.
+  delete process.env.CIRCLE_BUILD_NUM;
+
+  const ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = ENV;
+  });
+
+  describe('.ciNodeBuildId', () => {
+    describe('when KNAPSACK_PRO_CI_NODE_BUILD_ID is not defined on the environment', () => {
+      it('throws', () => {
+        expect(() => KnapsackProEnvConfig.ciNodeBuildId).toThrow(
+          /Missing environment variable KNAPSACK_PRO_CI_NODE_BUILD_ID/,
+        );
+      });
+    });
+
+    describe('when the build id is defined on a supported CI environment', () => {
+      it('returns it', () => {
+        const ciBuildId = 'some-build-id';
+        process.env.GITHUB_RUN_ID = ciBuildId;
+
+        expect(KnapsackProEnvConfig.ciNodeBuildId).toEqual(ciBuildId);
+      });
+    });
+
+    describe('when KNAPSACK_PRO_CI_NODE_BUILD_ID is defined on the environment', () => {
+      it('returns it', () => {
+        const ciBuildId = 'some-build-id';
+        process.env.KNAPSACK_PRO_CI_NODE_BUILD_ID = ciBuildId;
+        process.env.GITHUB_RUN_ID = 'some-other-build-id';
+
+        expect(KnapsackProEnvConfig.ciNodeBuildId).toEqual(ciBuildId);
+      });
+    });
+  });
+});

--- a/__tests__/knapsack-pro-env.config.spec.ts
+++ b/__tests__/knapsack-pro-env.config.spec.ts
@@ -29,7 +29,7 @@ describe('KnapsackProEnvConfig', () => {
       });
     });
 
-    describe('when KNAPSACK_PRO_CI_NODE_BUILD_ID is defined on the environment', () => {
+    describe('when KNAPSACK_PRO_CI_NODE_BUILD_ID is defined on the environment AND the build id is defined on a supported CI environment', () => {
       it('returns it', () => {
         const ciBuildId = 'some-build-id';
         process.env.KNAPSACK_PRO_CI_NODE_BUILD_ID = ciBuildId;

--- a/__tests__/knapsack-pro-env.config.spec.ts
+++ b/__tests__/knapsack-pro-env.config.spec.ts
@@ -30,7 +30,7 @@ describe('KnapsackProEnvConfig', () => {
     });
 
     describe('when KNAPSACK_PRO_CI_NODE_BUILD_ID is defined on the environment AND the build id is defined on a supported CI environment', () => {
-      it('returns it', () => {
+      it('returns the CI build ID defined on the environment', () => {
         const ciBuildId = 'some-build-id';
         process.env.KNAPSACK_PRO_CI_NODE_BUILD_ID = ciBuildId;
         process.env.GITHUB_RUN_ID = 'some-other-build-id';

--- a/src/config/knapsack-pro-env.config.ts
+++ b/src/config/knapsack-pro-env.config.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import childProcess = require('child_process');
 import { CIEnvConfig } from '.';
 import { KnapsackProLogger } from '../knapsack-pro-logger';
+import * as Urls from '../urls';
 
 const { spawnSync } = childProcess;
 
@@ -85,20 +86,9 @@ export class KnapsackProEnvConfig {
       return ciNodeBuildId;
     }
 
-    // this is key known to Knapsack Pro API, do not change it!
-    const knapsackProMissingBuildIdKey = 'missing-build-id';
-
-    // set env variable so next function call won't show information about missing build ID
-    process.env.KNAPSACK_PRO_CI_NODE_BUILD_ID = knapsackProMissingBuildIdKey;
-
-    knapsackProLogger.warn(
-      'CI node build ID not detected! Your tests will run anyway.\n\n' +
-        'If you want to be able to run more than one CI build at the same time for exactly the same commit hash, branch name and number of parallel CI nodes then you have to set unique KNAPSACK_PRO_CI_NODE_BUILD_ID environment variable.\n\n' +
-        'For instance you can generate KNAPSACK_PRO_CI_NODE_BUILD_ID=$(openssl rand - base64 32)\n\n' +
-        'Please ensure KNAPSACK_PRO_CI_NODE_BUILD_ID has the same value for all parallel CI nodes being part of the single CI build. Thanks to that the parallel nodes will consume tests from the same Queue.',
+    throw new Error(
+      `Missing environment variable KNAPSACK_PRO_CI_NODE_BUILD_ID. Read more at ${Urls.KNAPSACK_PRO_CI_NODE_BUILD_ID}`,
     );
-
-    return process.env.KNAPSACK_PRO_CI_NODE_BUILD_ID;
   }
 
   public static get commitHash(): string | never {

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,0 +1,2 @@
+export const KNAPSACK_PRO_CI_NODE_BUILD_ID =
+  'https://knapsackpro.com/perma/js/knapsack-pro-ci-node-build-id';


### PR DESCRIPTION
`KNAPSACK_PRO_CI_NODE_BUILD_ID` is a mandatory environment variable, so let's raise when it's missing.

JavaScript counterpart of https://github.com/KnapsackPro/knapsack_pro-ruby/pull/195