### PR TITLE
Add support for CI node retry count on GitHub Actions and Buildkite and don't run tests in Fallback Mode when a retried node can't connect with the API to avoid running a wrong set of tests.

### DIFF
--- a/__tests__/knapsack-pro-env.config.spec.ts
+++ b/__tests__/knapsack-pro-env.config.spec.ts
@@ -39,4 +39,30 @@ describe('KnapsackProEnvConfig', () => {
       });
     });
   });
+
+  describe('.ciNodeRetryCount', () => {
+    it('returns a default retry count', () => {
+      expect(KnapsackProEnvConfig.ciNodeRetryCount).toEqual(0);
+    });
+
+    describe('when the CI provider is Buildkite', () => {
+      describe('when BUILDKITE_RETRY_COUNT is set', () => {
+        it('returns the retry count', () => {
+          process.env.BUILDKITE_RETRY_COUNT = '1';
+
+          expect(KnapsackProEnvConfig.ciNodeRetryCount).toEqual(1);
+        });
+      });
+    });
+
+    describe('when the CI provider is GitHub Actions', () => {
+      describe('when GITHUB_RUN_ATTEMPT is set', () => {
+        it('returns the retry count', () => {
+          process.env.GITHUB_RUN_ATTEMPT = '2';
+
+          expect(KnapsackProEnvConfig.ciNodeRetryCount).toEqual(1);
+        });
+      });
+    });
+  });
 });

--- a/src/ci-providers/appveyor.ts
+++ b/src/ci-providers/appveyor.ts
@@ -14,6 +14,10 @@ export class AppVeyor extends CIProviderBase {
     return process.env.APPVEYOR_BUILD_ID;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.APPVEYOR_REPO_COMMIT;
   }

--- a/src/ci-providers/buildkite.ts
+++ b/src/ci-providers/buildkite.ts
@@ -13,6 +13,10 @@ export class Buildkite extends CIProviderBase {
     return process.env.BUILDKITE_BUILD_NUMBER;
   }
 
+  public static get ciNodeRetryCount(): string | void {
+    return process.env.BUILDKITE_RETRY_COUNT;
+  }
+
   public static get commitHash(): string | void {
     return process.env.BUILDKITE_COMMIT;
   }

--- a/src/ci-providers/ci-provider.base.ts
+++ b/src/ci-providers/ci-provider.base.ts
@@ -11,6 +11,10 @@ export abstract class CIProviderBase {
     throw new Error('nodeBuildId getter is not implemented!');
   }
 
+  public static get ciNodeRetryCount(): string | void {
+    throw new Error('ciNodeRetryCount getter is not implemented!');
+  }
+
   public static get commitHash(): string | void {
     throw new Error('commitHash getter is not implemented!');
   }

--- a/src/ci-providers/circle-ci.ts
+++ b/src/ci-providers/circle-ci.ts
@@ -13,6 +13,10 @@ export class CircleCI extends CIProviderBase {
     return process.env.CIRCLE_BUILD_NUM;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.CIRCLE_SHA1;
   }

--- a/src/ci-providers/cirrus-ci.ts
+++ b/src/ci-providers/cirrus-ci.ts
@@ -13,6 +13,10 @@ export class CirrusCI extends CIProviderBase {
     return process.env.CIRRUS_BUILD_ID;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.CIRRUS_CHANGE_IN_REPO;
   }

--- a/src/ci-providers/codefresh-ci.ts
+++ b/src/ci-providers/codefresh-ci.ts
@@ -14,6 +14,10 @@ export class CodefreshCI extends CIProviderBase {
     return process.env.CF_BUILD_ID;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.CF_REVISION;
   }

--- a/src/ci-providers/codeship.ts
+++ b/src/ci-providers/codeship.ts
@@ -13,6 +13,10 @@ export class Codeship extends CIProviderBase {
     return process.env.CI_BUILD_NUMBER;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.CI_COMMIT_ID;
   }

--- a/src/ci-providers/github-actions.ts
+++ b/src/ci-providers/github-actions.ts
@@ -16,6 +16,19 @@ export class GithubActions extends CIProviderBase {
     return process.env.GITHUB_RUN_ID;
   }
 
+  public static get ciNodeRetryCount(): string | void {
+    // A unique number for each attempt of a particular workflow run in a repository.
+    // This number begins at 1 for the workflow run's first attempt, and increments with each re-run.
+    const runAttempt = process.env.GITHUB_RUN_ATTEMPT;
+
+    if (runAttempt) {
+      const runAttemptNumber = parseInt(runAttempt, 10) - 1;
+      return String(runAttemptNumber);
+    }
+
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.GITHUB_SHA;
   }

--- a/src/ci-providers/gitlab-ci.ts
+++ b/src/ci-providers/gitlab-ci.ts
@@ -21,6 +21,10 @@ export class GitlabCI extends CIProviderBase {
     return process.env.CI_PIPELINE_ID || process.env.CI_BUILD_ID;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     // GitLab Release 9.0+ || GitLab Release 8.x
     return process.env.CI_COMMIT_SHA || process.env.CI_BUILD_REF;

--- a/src/ci-providers/heroku-ci.ts
+++ b/src/ci-providers/heroku-ci.ts
@@ -13,6 +13,10 @@ export class HerokuCI extends CIProviderBase {
     return process.env.HEROKU_TEST_RUN_ID;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.HEROKU_TEST_RUN_COMMIT_VERSION;
   }

--- a/src/ci-providers/semaphore-ci-2.ts
+++ b/src/ci-providers/semaphore-ci-2.ts
@@ -18,6 +18,10 @@ export class SemaphoreCI2 extends CIProviderBase {
     return process.env.SEMAPHORE_WORKFLOW_ID;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.SEMAPHORE_GIT_SHA;
   }

--- a/src/ci-providers/semaphore-ci.ts
+++ b/src/ci-providers/semaphore-ci.ts
@@ -18,6 +18,10 @@ export class SemaphoreCI extends CIProviderBase {
     return process.env.SEMAPHORE_BUILD_NUMBER;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.REVISION;
   }

--- a/src/ci-providers/travis-ci.ts
+++ b/src/ci-providers/travis-ci.ts
@@ -13,6 +13,10 @@ export class TravisCI extends CIProviderBase {
     return process.env.TRAVIS_BUILD_NUMBER;
   }
 
+  public static get ciNodeRetryCount(): void {
+    return undefined;
+  }
+
   public static get commitHash(): string | void {
     return process.env.TRAVIS_COMMIT;
   }

--- a/src/config/ci-env.config.ts
+++ b/src/config/ci-env.config.ts
@@ -26,6 +26,10 @@ export class CIEnvConfig {
     return this.ciEnvFor('ciNodeBuildId');
   }
 
+  public static get ciNodeRetryCount(): string | void {
+    return this.ciEnvFor('ciNodeRetryCount');
+  }
+
   public static get commitHash(): string | void {
     return this.ciEnvFor('commitHash');
   }

--- a/src/config/knapsack-pro-env.config.ts
+++ b/src/config/knapsack-pro-env.config.ts
@@ -91,6 +91,19 @@ export class KnapsackProEnvConfig {
     );
   }
 
+  public static get ciNodeRetryCount(): number {
+    if (process.env.KNAPSACK_PRO_CI_NODE_RETRY_COUNT) {
+      return parseInt(process.env.KNAPSACK_PRO_CI_NODE_RETRY_COUNT, 10);
+    }
+
+    const { ciNodeRetryCount } = CIEnvConfig;
+    if (ciNodeRetryCount) {
+      return parseInt(ciNodeRetryCount, 10);
+    }
+
+    return 0;
+  }
+
   public static get commitHash(): string | never {
     if (process.env.KNAPSACK_PRO_COMMIT_HASH) {
       return process.env.KNAPSACK_PRO_COMMIT_HASH;

--- a/src/knapsack-pro-core.ts
+++ b/src/knapsack-pro-core.ts
@@ -1,5 +1,6 @@
 import { KnapsackProAPI } from './knapsack-pro-api';
 import { QueueApiResponseCodes } from './api-response-codes';
+import { KnapsackProEnvConfig } from './config';
 import { KnapsackProLogger } from './knapsack-pro-logger';
 import { FallbackTestDistributor } from './fallback-test-distributor';
 import { TestFilesFinder } from './test-files-finder';
@@ -9,6 +10,7 @@ import {
   onQueueSuccessType,
   testFilesToExecuteType,
 } from './types';
+import * as Urls from './urls';
 
 export class KnapsackProCore {
   private knapsackProAPI: KnapsackProAPI;
@@ -92,6 +94,12 @@ export class KnapsackProCore {
         }
 
         onFailure(error);
+
+        if (KnapsackProEnvConfig.ciNodeRetryCount > 0) {
+          throw new Error(
+            `No connection to Knapsack Pro API to determine the set of tests that should run on the retried CI node. Please retry the CI node to reconnect with the API or create a new commit to start another CI build that could run tests in Fallback Mode in case of persisting connection issues with the API. Learn more ${Urls.QUEUE_MODE_CONNECTION_ERROR_AND_POSITIVE_RETRY_COUNT}`,
+          );
+        }
 
         this.knapsackProLogger.warn(
           'Fallback Mode has started. We could not connect to Knapsack Pro API. Your tests will be executed based on test file names.\n\nIf other CI nodes were able to connect to Knapsack Pro API then you may notice that some of the test files were executed twice across CI nodes. Fallback Mode guarantees each of test files is run at least once as a part of CI build.',

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,2 +1,4 @@
 export const KNAPSACK_PRO_CI_NODE_BUILD_ID =
   'https://knapsackpro.com/perma/js/knapsack-pro-ci-node-build-id';
+export const QUEUE_MODE_CONNECTION_ERROR_AND_POSITIVE_RETRY_COUNT =
+  'https://knapsackpro.com/perma/js/queue-mode-connection-error-and-positive-retry-count';


### PR DESCRIPTION
Don't run tests in Fallback Mode when a retried node can't connect with the API to avoid running a wrong set of tests.

Support out of the box for:

* GitHub Actions
* Buildkite

You can manually set KNAPSACK_PRO_CI_NODE_RETRY_COUNT=1 for a node that is retried to prevent Fallback Mode.

# Related

* [`KNAPSACK_PRO_CI_NODE_RETRY_COUNT`](https://docs.knapsackpro.com/ruby/reference/#knapsack_pro_ci_node_retry_count)